### PR TITLE
Adding undocumented not (!) tag expression

### DIFF
--- a/user/execution/tagged_execution.md
+++ b/user/execution/tagged_execution.md
@@ -24,8 +24,11 @@ gauge --tags "search & admin" SPEC_FILE_NAME
 
 ### Tags can be selected using expressions
 __Examples__
+* __!TagA:__  Selects specs/scenarios that do not have TagA.
 * __TagA & TagB:__  Selects specs/scenarios that have both TagA and TagB.
+* __TagA & !TagB:__  Selects specs/scenarios that have TagA and not TagB.
 * __TagA | TagB:__  Selects specs/scenarios that have either TagA or TagB.
 * __(TagA & TagB) | TagC:__  Selects specs/scenarios that have either TagC or both the tags TagA and TagB
+* __!(TagA & TagB) | TagC:__  Selects specs/scenarios that have either TagC or do not have both the tags TagA and TagB
 * __(TagA | TagB) & TagC:__  Selects specs/scenarios that either TagA and TagC or TagB and TagC
 


### PR DESCRIPTION
The Not (`!`) operator for tags is functional, but currently undocumented. I am adding it to the list of examples.