### PR TITLE
Steps must be list items otherwise they do not execute

### DIFF
--- a/user/test_code/ruby/ruby.md
+++ b/user/test_code/ruby/ruby.md
@@ -27,7 +27,7 @@ end
 **Step:**
 
 ````
-Create following "admin" users
+* Create following "admin" users
 |id |   name  |
 |---|---------|
 |123| prateek |


### PR DESCRIPTION
Is this a typo?

It seems the `*` is required in order to execute the step. the downside being the table does not look good at all.

For example, this executes but is ugly:

* Addition examples (failing)
| A   | B     | C    |
| ----| ----- | ---- |
| 2   | 0     | 1    |
| 1   | 1     | 2    |

This one is not run at all:

Addition examples (failing)
| A   | B     | C    |
| ----| ----- | ---- |
| 2   | 0     | 1    |
| 1   | 1     | 2    |

And this is what we really want:

* Addition examples (failing)

| A   | B     | C    |
| ----| ----- | ---- |
| 2   | 0     | 1    |
| 1   | 1     | 2    |

This last one fails with error: `Step implementation not found. Addition examples (failing)`