### PR TITLE
Updating gradle plugin version to 1.4.1

### DIFF
--- a/user/dependency_management/gradle-plugin.md
+++ b/user/dependency_management/gradle-plugin.md
@@ -21,8 +21,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.thoughtworks.gauge.gradle:gauge-gradle-plugin:1.4.0'
-        classpath files("$projectDir/libs")
+        classpath 'com.thoughtworks.gauge.gradle:gauge-gradle-plugin:1.4.1'
     }
 }
 

--- a/user/test_code/java/using_build_tools.md
+++ b/user/test_code/java/using_build_tools.md
@@ -68,8 +68,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.thoughtworks.gauge.gradle:gauge-gradle-plugin:1.4.0'
-        classpath files("$projectDir/libs")
+        classpath 'com.thoughtworks.gauge.gradle:gauge-gradle-plugin:1.4.1'
     }
 }
 
@@ -88,14 +87,6 @@ gauge {
     env = 'dev'
     tags = 'tag1'
     additionalFlags = '--verbose'
-}
-
-// copying required dependencies for Gauge (required)
-task copyLibs {
-    copy {
-        from configurations.runtime
-        into "$projectDir/libs"
-    }
 }
 
 ````


### PR DESCRIPTION
The jar files uploaded to maven as part of v1.4.0 has some errors. Recompiled and uploaded new jar files as v1.4.1